### PR TITLE
FEAT - (serviços) -  Refatora o estado da UI para uma interface selada e aprimora os recursos de acessibilidade

### DIFF
--- a/app/src/main/java/com/pdm/barbershop/ui/common/format/Url.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/common/format/Url.kt
@@ -1,0 +1,21 @@
+package com.pdm.barbershop.ui.common.format
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * URL encoding helpers to safely build query strings and route arguments.
+ * - encodeUrlComponent: encodes a single component (query value or path segment)
+ * - toEncodedQueryString: builds a sorted, encoded query string from a map
+ */
+fun String.encodeUrlComponent(): String =
+    URLEncoder.encode(this, StandardCharsets.UTF_8.toString())
+
+fun Map<String, String?>.toEncodedQueryString(): String =
+    entries
+        .filter { it.value != null }
+        .sortedBy { it.key }
+        .joinToString(separator = "&") { (k, v) ->
+            "${k.encodeUrlComponent()}=${v!!.encodeUrlComponent()}"
+        }
+

--- a/app/src/main/java/com/pdm/barbershop/ui/feature/services/ServicesScreen.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/feature/services/ServicesScreen.kt
@@ -26,38 +26,37 @@ fun ServicesScreen(
     val state by viewModel.state
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // Segmented buttons fixos no topo
-        Box(
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-        ) {
-            ServicesSegmentedControl(
-                selectedTab = state.selectedTab,
-                onSelect = viewModel::onTabSelected
-            )
-        }
-
-        // Conteúdo
-        when {
-            state.isLoading -> {
+        when (val s = state) {
+            is ServicesUiState.Loading -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
                 }
             }
-            state.error != null -> {
+            is ServicesUiState.Error -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Text(
-                        text = state.error ?: "Erro",
+                        text = s.message,
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.error
                     )
                 }
             }
-            else -> {
-                val list: List<CatalogItem> = when (state.selectedTab) {
-                    ServicesTab.Services -> state.services
-                    ServicesTab.Products -> state.products
+            is ServicesUiState.Content -> {
+                // Segmented buttons no topo
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    ServicesSegmentedControl(
+                        selectedTab = s.selectedTab,
+                        onSelect = viewModel::onTabSelected
+                    )
+                }
+
+                val list: List<CatalogItem> = when (s.selectedTab) {
+                    ServicesTab.Services -> s.services
+                    ServicesTab.Products -> s.products
                 }
 
                 LazyColumn(

--- a/app/src/main/java/com/pdm/barbershop/ui/feature/services/ServicesUiState.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/feature/services/ServicesUiState.kt
@@ -4,11 +4,13 @@ import com.pdm.barbershop.domain.model.CatalogItem
 
 enum class ServicesTab { Services, Products }
 
-data class ServicesUiState(
-    val isLoading: Boolean = true,
-    val selectedTab: ServicesTab = ServicesTab.Services,
-    val services: List<CatalogItem> = emptyList(),
-    val products: List<CatalogItem> = emptyList(),
-    val error: String? = null
-)
-
+// Sealed UI state to clearly represent loading, success, and error
+sealed interface ServicesUiState {
+    data object Loading : ServicesUiState
+    data class Content(
+        val selectedTab: ServicesTab = ServicesTab.Services,
+        val services: List<CatalogItem> = emptyList(),
+        val products: List<CatalogItem> = emptyList()
+    ) : ServicesUiState
+    data class Error(val message: String) : ServicesUiState
+}

--- a/app/src/main/java/com/pdm/barbershop/ui/feature/services/components/ServiceCard.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/feature/services/components/ServiceCard.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.pdm.barbershop.R
@@ -33,8 +35,18 @@ fun ServiceCard(
     item: CatalogItem,
     modifier: Modifier = Modifier,
 ) {
+    val priceText = item.price.toBRL()
+    val durationText = item.durationMinutes?.let { mins ->
+        stringResource(R.string.duration_minutes, mins)
+    }
+    val cardA11y = listOfNotNull(item.name, priceText, durationText).joinToString(
+        separator = ", "
+    )
+
     ElevatedCard(
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics { this.contentDescription = cardA11y }
     ) {
         Row(
             modifier = Modifier.padding(16.dp),
@@ -45,7 +57,10 @@ fun ServiceCard(
                     CatalogItemType.SERVICE -> Icons.Outlined.ContentCut
                     CatalogItemType.PRODUCT -> Icons.Outlined.ShoppingBag
                 },
-                contentDescription = null,
+                contentDescription = when (item.type) {
+                    CatalogItemType.SERVICE -> stringResource(R.string.services_tab_services)
+                    CatalogItemType.PRODUCT -> stringResource(R.string.services_tab_products)
+                },
                 tint = MaterialTheme.colorScheme.primary
             )
             Column(modifier = Modifier.weight(1f)) {
@@ -71,11 +86,11 @@ fun ServiceCard(
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     AssistChip(
                         onClick = { },
-                        label = { Text(item.price.toBRL()) },
+                        label = { Text(priceText) },
                         leadingIcon = {
                             Icon(
                                 Icons.Outlined.MonetizationOn,
-                                contentDescription = null
+                                contentDescription = priceText
                             )
                         },
                         colors = AssistChipDefaults.assistChipColors(
@@ -91,7 +106,7 @@ fun ServiceCard(
                             leadingIcon = {
                                 Icon(
                                     Icons.Outlined.AccessTime,
-                                    contentDescription = null
+                                    contentDescription = stringResource(R.string.duration_minutes, mins)
                                 )
                             }
                         )

--- a/app/src/main/java/com/pdm/barbershop/ui/feature/services/components/ServicesSegmentedControl.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/feature/services/components/ServicesSegmentedControl.kt
@@ -30,10 +30,9 @@ fun ServicesSegmentedControl(
                 selected = selectedTab == tab,
                 onClick = { onSelect(tab) },
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = items.size),
-                icon = { Icon(icon, contentDescription = null) },
+                icon = { Icon(icon, contentDescription = label) },
                 label = { Text(label) },
             )
         }
     }
 }
-

--- a/app/src/main/res/values/strings_services.xml
+++ b/app/src/main/res/values/strings_services.xml
@@ -5,4 +5,12 @@
     <string name="services_tab_products">Produtos</string>
     <string name="duration_minutes">%1$d min</string>
     <string name="price_from">A partir de %1$s</string>
+
+    <!-- Accessibility -->
+    <string name="a11y_card_item_full">%1$s, preço %2$s, duração %3$d minutos</string>
+    <string name="a11y_card_item_no_duration">%1$s, preço %2$s</string>
+    <string name="a11y_service_icon">Serviço</string>
+    <string name="a11y_product_icon">Produto</string>
+    <string name="a11y_price">Preço %1$s</string>
+    <string name="a11y_duration">Duração %1$d minutos</string>
 </resources>


### PR DESCRIPTION
Refatoração do estado da UI (Services): trocou o antigo data class com flags para uma sealed interface com três estados explícitos: Loading, Content e Error. Isso deixa o fluxo de renderização mais claro e seguro.
ViewModel (ServicesViewModel):
Inicializa em Loading.
No sucesso, publica um estado Content, preservando a aba selecionada anterior (selectedTab) quando possível.
No erro, publica um estado Error com mensagem amigável.
onTabSelected só altera o estado quando o estado atual é Content.
Tela (ServicesScreen): agora usa um when com o estado selado para renderizar Loading (spinner), Error (mensagem) e Content (lista + segmented control).
Acessibilidade (a11y):
ServiceCard passou a ter contentDescription completo (nome, preço e duração) no container e descriptions nos ícones dos chips.
Segmented control passou a fornecer contentDescription nos ícones (antes era null).
Novas strings de a11y adicionadas ao resources.
Utilitário de URL: adicionou helpers para codificação segura de componentes e construção de query strings ordenadas e codificadas.