### PR TITLE
feat(navegação): Implementa a manipulação de deep links e atualiza as dependências

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedIn" />
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -6,12 +8,12 @@ plugins {
 
 android {
     namespace = "com.pdm.barbershop"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.pdm.barbershop"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 
@@ -31,40 +33,59 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
-    kotlinOptions { jvmTarget = "17" }
 
     buildFeatures { compose = true }
 
     packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
 }
 
+kotlin {
+    jvmToolchain(17)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 dependencies {
-    implementation("io.coil-kt:coil-compose:2.6.0")
+    // Coil
+    implementation(libs.coil.compose)
 
     // Compose BOM
-    implementation(platform("androidx.compose:compose-bom:2024.10.01"))
+    implementation(platform(libs.androidx.compose.bom))
 
-    // Material 3
-    implementation("androidx.compose.material3:material3")
+    // Compose core
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
+    implementation(libs.androidx.compose.ui.tooling.preview)
 
-    // Ícones Material
-    implementation("androidx.compose.material:material-icons-extended")
+    // Material 3 e ícones
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
 
     // Navigation Compose
-    implementation("androidx.navigation:navigation-compose:2.8.0")
+    implementation(libs.androidx.navigation.compose)
 
-    // Activity/Runtime Compose
-    implementation("androidx.activity:activity-compose:1.9.2")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
+    // Activity/Runtime/Lifecycle Compose
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
-    // Optional: Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
-    implementation(libs.androidx.ui.graphics)
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.android)
+
+    // Firebase tools
     implementation(libs.firebase.crashlytics.buildtools)
 
+    // Core library desugaring
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     // Tooling
-    debugImplementation("androidx.compose.ui:ui-tooling")
-    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation(libs.androidx.compose.ui.tooling)
+
+    // Tests
+    testImplementation(libs.junit.jupiter)
+    testImplementation(kotlin("test"))
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,46 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Deep link: HTTPS host + rotas principais (um por filtro) -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="barbershop.app" android:pathPrefix="/home" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="barbershop.app" android:pathPrefix="/services" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="barbershop.app" android:pathPrefix="/barbers" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="barbershop.app" android:pathPrefix="/schedule" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="barbershop.app" android:pathPrefix="/profile" />
+            </intent-filter>
+
+            <!-- Deep link: Custom scheme (geral) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="barbershop" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/java/com/pdm/barbershop/navegation/AppNavHost.kt
+++ b/app/src/main/java/com/pdm/barbershop/navegation/AppNavHost.kt
@@ -1,25 +1,23 @@
 package com.pdm.barbershop.navegation
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import com.pdm.barbershop.ui.feature.about.AboutScreen
 import com.pdm.barbershop.ui.feature.appointments.AppointmentsScreen
 import com.pdm.barbershop.ui.feature.barbers.BarbersScreen
 import com.pdm.barbershop.ui.feature.comanda.ComandaHistoryScreen
 import com.pdm.barbershop.ui.feature.help.HelpScreen
-import com.pdm.barbershop.ui.feature.home.HomeScreen // Import da HomeScreen
+import com.pdm.barbershop.ui.feature.home.HomeScreen
 import com.pdm.barbershop.ui.feature.notifications.NotificationsScreen
 import com.pdm.barbershop.ui.feature.profile.EditProfileScreen
 import com.pdm.barbershop.ui.feature.profile.ProfileScreen
 import com.pdm.barbershop.ui.feature.schedule.ScheduleScreen
 import com.pdm.barbershop.ui.feature.services.ServicesScreen
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AppNavHost(
     navController: NavHostController,
@@ -31,23 +29,51 @@ fun AppNavHost(
         startDestination = startDestination,
         modifier = modifier
     ) {
-        composable(AppDestination.Home.route) {
+        composable(
+            route = AppDestination.Home.route,
+            deepLinks = listOf(
+                navDeepLink { uriPattern = "https://barbershop.app/home" },
+                navDeepLink { uriPattern = "barbershop://home" }
+            )
+        ) {
             HomeScreen(
                 onNavigateToSchedule = { navController.navigate(AppDestination.Schedule.route) },
                 onNavigateToServices = { navController.navigate(AppDestination.Services.route) },
                 onNavigateToBarbers = { navController.navigate(AppDestination.Barbers.route) },
-                onNavigateToAppointmentDetails = { appointmentId ->
-                    // No futuro, você pode querer uma tela de detalhes específica.
-                    // Por agora, navega para a lista geral de agendamentos.
+                onNavigateToAppointmentDetails = { _ ->
                     navController.navigate(AppDestination.Appointments.route)
                 }
             )
         }
-        composable(AppDestination.Services.route) { ServicesScreen() }
-        composable(AppDestination.Barbers.route) { BarbersScreen() }
-        composable(AppDestination.Schedule.route) { ScheduleScreen() }
+        composable(
+            route = AppDestination.Services.route,
+            deepLinks = listOf(
+                navDeepLink { uriPattern = "https://barbershop.app/services" },
+                navDeepLink { uriPattern = "barbershop://services" }
+            )
+        ) { ServicesScreen() }
+        composable(
+            route = AppDestination.Barbers.route,
+            deepLinks = listOf(
+                navDeepLink { uriPattern = "https://barbershop.app/barbers" },
+                navDeepLink { uriPattern = "barbershop://barbers" }
+            )
+        ) { BarbersScreen() }
+        composable(
+            route = AppDestination.Schedule.route,
+            deepLinks = listOf(
+                navDeepLink { uriPattern = "https://barbershop.app/schedule" },
+                navDeepLink { uriPattern = "barbershop://schedule" }
+            )
+        ) { ScheduleScreen() }
 
-        composable(AppDestination.Profile.route) {
+        composable(
+            route = AppDestination.Profile.route,
+            deepLinks = listOf(
+                navDeepLink { uriPattern = "https://barbershop.app/profile" },
+                navDeepLink { uriPattern = "barbershop://profile" }
+            )
+        ) {
             ProfileScreen(
                 onEditProfileClick = { navController.navigate(AppDestination.EditProfile.route) },
                 onAppointmentsClick = { navController.navigate(AppDestination.Appointments.route) },

--- a/app/src/main/java/com/pdm/barbershop/ui/AppScaffold.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/AppScaffold.kt
@@ -1,5 +1,6 @@
 package com.pdm.barbershop.ui
 
+import android.app.Activity
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -9,7 +10,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.pdm.barbershop.navegation.AppDestination
@@ -20,6 +23,17 @@ import com.pdm.barbershop.ui.components.CustomBottomBar
 @Composable
 fun AppScaffold() {
     val navController = rememberNavController()
+
+    // Handle initial deep link intent
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        val activity = context as? Activity
+        val intent = activity?.intent
+        if (intent != null) {
+            navController.handleDeepLink(intent)
+        }
+    }
+
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
     val currentDestination = AppDestination.fromRoute(currentRoute)
@@ -34,7 +48,7 @@ fun AppScaffold() {
                 CenterAlignedTopAppBar(
                     title = { Text(text = currentDestination?.title ?: "Barbershop") },
                     // NOVO: Aplica as cores do nosso tema
-                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.primary,
                         titleContentColor = MaterialTheme.colorScheme.onPrimary
                     )

--- a/app/src/main/java/com/pdm/barbershop/ui/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/feature/home/HomeScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +33,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.pdm.barbershop.domain.model.Appointment
 import com.pdm.barbershop.domain.model.Service
@@ -46,8 +46,25 @@ fun HomeScreen(
     onNavigateToBarbers: () -> Unit = {},
     onNavigateToAppointmentDetails: (String) -> Unit = {}
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    HomeContent(
+        uiState = uiState,
+        onNavigateToSchedule = onNavigateToSchedule,
+        onNavigateToServices = onNavigateToServices,
+        onNavigateToBarbers = onNavigateToBarbers,
+        onNavigateToAppointmentDetails = onNavigateToAppointmentDetails
+    )
+}
+
+@Composable
+private fun HomeContent(
+    uiState: HomeUiState,
+    onNavigateToSchedule: () -> Unit,
+    onNavigateToServices: () -> Unit,
+    onNavigateToBarbers: () -> Unit,
+    onNavigateToAppointmentDetails: (String) -> Unit
+) {
     if (uiState.isLoading) {
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -60,7 +77,7 @@ fun HomeScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState()) // Para permitir rolagem se o conteúdo for grande
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp)
         ) {
             // 1. Saudação
@@ -72,10 +89,7 @@ fun HomeScreen(
             uiState.nextAppointment?.let { appointment ->
                 NextAppointmentCard(
                     appointment = appointment,
-                    onSeeDetailsClicked = { 
-                        // viewModel.onSeeDetailsClicked(appointment.id) 
-                        onNavigateToAppointmentDetails(appointment.id)
-                    }
+                    onSeeDetailsClicked = { onNavigateToAppointmentDetails(appointment.id) }
                 )
                 Spacer(modifier = Modifier.height(24.dp))
             }
@@ -93,10 +107,7 @@ fun HomeScreen(
             uiState.lastServiceForRebooking?.let { service ->
                 QuickRebookCard(
                     service = service,
-                    onRebookClicked = { 
-                        // viewModel.onRebookServiceClicked(service.id)
-                        onNavigateToSchedule() // Ou uma navegação específica para reagendamento com o ID do serviço
-                    }
+                    onRebookClicked = { onNavigateToSchedule() }
                 )
             }
         }
@@ -244,8 +255,20 @@ fun QuickRebookCard(service: Service, onRebookClicked: () -> Unit) {
 @Preview(showBackground = true, name = "HomeScreen Preview")
 @Composable
 fun HomeScreenPreview() {
+    val sampleState = HomeUiState(
+        userName = "Eduardo",
+        nextAppointment = Appointment("1", "24/09", "15:00", "Corte + Barba", "Fernando Silva", "Confirmado"),
+        lastServiceForRebooking = Service("s1", "Corte Masculino", 50.0, 45, Icons.Filled.ContentCut),
+        isLoading = false
+    )
     MaterialTheme {
-        HomeScreen(viewModel = HomeViewModel())
+        HomeContent(
+            uiState = sampleState,
+            onNavigateToSchedule = {},
+            onNavigateToServices = {},
+            onNavigateToBarbers = {},
+            onNavigateToAppointmentDetails = {}
+        )
     }
 }
 

--- a/app/src/main/java/com/pdm/barbershop/ui/feature/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/feature/schedule/ScheduleScreen.kt
@@ -1,7 +1,6 @@
 package com.pdm.barbershop.ui.feature.schedule
 
-import android.os.Build
-import androidx.annotation.RequiresApi
+import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -18,27 +17,26 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.pdm.barbershop.domain.model.Barber
 import com.pdm.barbershop.domain.model.Service
 import java.text.NumberFormat
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import java.util.*
 
-@RequiresApi(Build.VERSION_CODES.O)
+@SuppressLint("NewApi")
 @Composable
 fun ScheduleScreen(
     viewModel: ScheduleViewModel = viewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier
@@ -178,10 +176,9 @@ fun TimeSlotChip(time: String, isSelected: Boolean, onTimeSelected: () -> Unit) 
     )
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun DateChip(date: LocalDate, isSelected: Boolean, onDateSelected: () -> Unit) {
-    val formatter = DateTimeFormatter.ofPattern("dd/MM")
+    val formatter = java.time.format.DateTimeFormatter.ofPattern("dd/MM")
     BaseChip(
         label = date.format(formatter),
         isSelected = isSelected,
@@ -258,11 +255,10 @@ fun SchedulingStep(title: String, content: @Composable () -> Unit) {
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AppointmentSummaryCard(uiState: ScheduleUiState) {
     val currencyFormat = NumberFormat.getCurrencyInstance(Locale.getDefault())
-    val dateFormatter = DateTimeFormatter.ofPattern("EEEE, dd 'de' MMMM", Locale("pt", "BR"))
+    val dateFormatter = java.time.format.DateTimeFormatter.ofPattern("EEEE, dd 'de' MMMM", Locale.forLanguageTag("pt-BR"))
 
     OutlinedCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/app/src/main/java/com/pdm/barbershop/ui/feature/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/pdm/barbershop/ui/feature/schedule/ScheduleViewModel.kt
@@ -1,7 +1,5 @@
 package com.pdm.barbershop.ui.feature.schedule
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCut
 import androidx.compose.material.icons.filled.Face
@@ -31,7 +29,6 @@ data class ScheduleUiState(
     val isLoadingTimeSlots: Boolean = false
 )
 
-@RequiresApi(Build.VERSION_CODES.O)
 class ScheduleViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(ScheduleUiState())
     val uiState = _uiState.asStateFlow()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,36 +1,52 @@
 [versions]
 agp = "8.13.0"
-kotlin = "2.0.21"
-coreKtx = "1.10.1"
-junit = "4.13.2"
-junitVersion = "1.1.5"
-espressoCore = "3.5.1"
-lifecycleRuntimeKtx = "2.6.1"
-activityCompose = "1.8.0"
-composeBom = "2024.09.00"
-uiGraphics = "1.9.1"
+kotlin = "2.2.20"
+lifecycleRuntimeKtx = "2.9.4"
+activityCompose = "1.11.0"
+composeBom = "2025.10.00"
 firebaseCrashlyticsBuildtools = "3.0.6"
+junitJupiter = "6.0.0"
+coilCompose = "2.7.0"
+navigationCompose = "2.9.5"
+lifecycleViewModelCompose = "2.9.4"
+coroutinesAndroid = "1.10.2"
+desugarJdkLibs = "2.1.5"
 
 [libraries]
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+# Compose BOM
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+
+# Compose UI artifacts (version managed by BOM)
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics", version.ref = "uiGraphics" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+
+# AndroidX integration libraries
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
+
+# Coroutines
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutinesAndroid" }
+
+# Coil
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coilCompose" }
+
+# Firebase tools
 firebase-crashlytics-buildtools = { group = "com.google.firebase", name = "firebase-crashlytics-buildtools", version.ref = "firebaseCrashlyticsBuildtools" }
+
+# Desugaring
+desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdkLibs" }
+
+# Test
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junitJupiter" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-


### PR DESCRIPTION
Deep links (HTTPS e esquema customizado) para as rotas principais:
Manifest adiciona intent-filters com autoVerify para: /home, /services, /barbers, /schedule, /profile no host https://barbershop.app/.
Esquema customizado barbershop:// suportado genericamente.
Navegação com NavHost atualizada para reconhecer deep links:
Cada composable principal recebeu deepLinks com uriPattern tanto para https quanto para barbershop://.
Tratamento do deep link inicial:
AppScaffold chama navController.handleDeepLink(intent) no primeiro frame (LaunchedEffect).
Atualizações de dependências e build:
compileSdk/targetSdk atualizados para 36.
Habilitado coreLibraryDesugaring e adicionado desugar_jdk_libs.
Kotlin jvmToolchain(17) + compilerOptions.jvmTarget = 17.
Migração para Version Catalog (libs.versions.toml) e uso de aliases libs.* no build.gradle.kts.
Atualização de versões: Kotlin 2.2.20, Compose BOM 2025.10.00, Activity 1.11.0, Navigation 2.9.5, Lifecycle 2.9.4, Coroutines 1.10.2, Coil 2.7.0, JUnit Jupiter 6.0.0.
Melhoria de coleta de estado com lifecycle:
Substituição de collectAsState por collectAsStateWithLifecycle em Home e Schedule.
Extração de HomeContent para facilitar preview/testes.
Limpeza de anotações/compatibilidade:
Remoção de @RequiresApi em navegação e schedule; uso de DateTimeFormatter e Locale com referencias totalmente qualificadas; @SuppressLint("NewApi") quando pertinente.
Ajustes IDE/config:
.idea ajustado para languageLevel/bytecode target 17.
Adicionado .idea/studiobot.xml (shareContext: OptedIn).
Pequeno ajuste em TopAppBarDefaults: topAppBarColors ao invés de centerAlignedTopAppBarColors.